### PR TITLE
Add mobile controls that appear on mobile but disappear on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,34 @@
             display: block;
             background: #87CEEB;
         }
+        .mobile-controls {
+            display: none;
+            position: absolute;
+            bottom: 20px;
+            width: 100%;
+            text-align: center;
+        }
+        .mobile-controls button {
+            width: 60px;
+            height: 60px;
+            font-size: 24px;
+            margin: 0 10px;
+        }
+        @media (max-width: 768px) {
+            .mobile-controls {
+                display: block;
+            }
+        }
     </style>
 </head>
 
 <body>
     <canvas id="gameCanvas"></canvas>
+    <div class="mobile-controls">
+        <button id="leftButton">←</button>
+        <button id="jumpButton">↑</button>
+        <button id="rightButton">→</button>
+    </div>
     <script>
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -196,6 +219,31 @@
                 player.dx = 0;
             }
         });
+
+        function handleTouchStart(e) {
+            const touch = e.target.id;
+            if (touch === 'leftButton') {
+                player.dx = -player.speed;
+            } else if (touch === 'rightButton') {
+                player.dx = player.speed;
+            } else if (touch === 'jumpButton') {
+                jump();
+            }
+        }
+
+        function handleTouchEnd(e) {
+            const touch = e.target.id;
+            if (touch === 'leftButton' || touch === 'rightButton') {
+                player.dx = 0;
+            }
+        }
+
+        document.getElementById('leftButton').addEventListener('touchstart', handleTouchStart);
+        document.getElementById('rightButton').addEventListener('touchstart', handleTouchStart);
+        document.getElementById('jumpButton').addEventListener('touchstart', handleTouchStart);
+
+        document.getElementById('leftButton').addEventListener('touchend', handleTouchEnd);
+        document.getElementById('rightButton').addEventListener('touchend', handleTouchEnd);
 
         function drawScore() {
             ctx.fillStyle = 'black';


### PR DESCRIPTION
Add mobile-specific controls to `index.html` that appear on mobile devices and disappear on desktop.

* **CSS Changes**
  - Add `.mobile-controls` class to hide controls by default and position them at the bottom of the screen.
  - Add styles for buttons within `.mobile-controls` to make them touch-friendly.
  - Add media query to display `.mobile-controls` on screens with a max-width of 768px.

* **HTML Changes**
  - Add a `div` with the class `mobile-controls` containing three buttons for left, jump, and right actions.

* **JavaScript Changes**
  - Add `handleTouchStart` and `handleTouchEnd` functions to handle touch events for the mobile controls.
  - Add event listeners for `touchstart` and `touchend` events on the mobile control buttons.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EliteGamerCJ/MAKEITOUT?shareId=XXXX-XXXX-XXXX-XXXX).